### PR TITLE
Order posts by their posted_on date

### DIFF
--- a/cmd/blog_backend/daos/post.go
+++ b/cmd/blog_backend/daos/post.go
@@ -26,6 +26,7 @@ func (dao *PostDAO) Get(id uint) (*models.Post, error) {
 
 func (dao *PostDAO) FindAll() []models.Post {
 	var posts []models.Post
-	config.Config.DB.Find(&posts)
+	config.Config.DB.Order("posted_on DESC").
+		Find(&posts)
 	return posts
 }

--- a/cmd/blog_backend/daos/post_test.go
+++ b/cmd/blog_backend/daos/post_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/MartinHeinz/blog-backend/cmd/blog_backend/test_data"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 func TestPostDAO_Get(t *testing.T) {
@@ -40,4 +41,19 @@ func TestPostDAO_FindAll(t *testing.T) {
 	posts := dao.FindAll()
 
 	assert.Equal(t, 3, len(posts))
+}
+
+func TestPostDAO_FindAllOrdered(t *testing.T) {
+	timeFormat := "2006-01-02 15:04:05"
+	config.Config.DB = test_data.ResetDB()
+	dao := NewPostDAO()
+
+	posts := dao.FindAll()
+
+	firstPostDate, _ := time.Parse(timeFormat, "2019-05-30 19:00:00")
+	assert.Equal(t, firstPostDate, posts[0].PostedOn)
+	secondPostDate, _ := time.Parse(timeFormat, "2019-02-24 13:00:00")
+	assert.Equal(t, secondPostDate, posts[1].PostedOn)
+	thirdPostDate, _ := time.Parse(timeFormat, "2018-08-24 14:00:00")
+	assert.Equal(t, thirdPostDate, posts[2].PostedOn)
 }

--- a/cmd/blog_backend/test_data/test_case_data/post_t3.json
+++ b/cmd/blog_backend/test_data/test_case_data/post_t3.json
@@ -1,18 +1,18 @@
 {
   "posts": [
     {
-      "id": 1,
+      "id": 3,
       "created_at": "0001-01-01T00:00:00Z",
       "updated_at": "0001-01-01T00:00:00Z",
       "deleted_at": null,
-      "title": "First Blog Post",
-      "text": "This is blog about something.",
+      "title": "3rd Blog Post",
+      "text": "Another dummy content",
       "author": "Martin",
       "next": null,
-      "next_post_id": 2,
+      "next_post_id": 0,
       "previous": null,
-      "previous_post_id": 0,
-      "posted_on": "2018-08-24T14:00:00Z",
+      "previous_post_id": 2,
+      "posted_on": "2019-05-30T19:00:00Z",
       "sections": null,
       "tags": null
     },
@@ -33,18 +33,18 @@
       "tags": null
     },
     {
-      "id": 3,
+      "id": 1,
       "created_at": "0001-01-01T00:00:00Z",
       "updated_at": "0001-01-01T00:00:00Z",
       "deleted_at": null,
-      "title": "3rd Blog Post",
-      "text": "Another dummy content",
+      "title": "First Blog Post",
+      "text": "This is blog about something.",
       "author": "Martin",
       "next": null,
-      "next_post_id": 0,
+      "next_post_id": 2,
       "previous": null,
-      "previous_post_id": 2,
-      "posted_on": "2019-05-30T19:00:00Z",
+      "previous_post_id": 0,
+      "posted_on": "2018-08-24T14:00:00Z",
       "sections": null,
       "tags": null
     }


### PR DESCRIPTION
Hey 👋 ,

Every month or so I'll end up on your blog as it's bookmarked. The posts are interesting and always very detailed. 
Because I'm not a weekly visitor I usually end up reading 2/3 new posts at a time. This is where I stumble upon a challenge:

The posts on https://martinheinz.dev/ and https://martinheinz.dev/posts/ are not ordered by their date. This might cause visitors to miss the most recent ones. For example, your post of 1 oct 2020 is the last item on the overview page right now.

This PR should add an ordering to the objects returned in `/api/v1/posts/`, ultimately resulting in an ordered list on your homepage and /post overview.

Let me know if I missed something or if you have other thoughts.